### PR TITLE
Fix mint behavior

### DIFF
--- a/examples/counter/contract/src/counter.compact
+++ b/examples/counter/contract/src/counter.compact
@@ -12,13 +12,10 @@ export circuit increment(): [] {
 }
 
 export circuit mint(nonce: Bytes<32>, recipient: ZswapCoinPublicKey): [] {
-  const token = mint_token(
-    "Test                            ",
+  mint_token(
+    pad(32, "Test"),
     100000000,
     nonce,
-    right<ZswapCoinPublicKey, ContractAddress>(kernel.self())
-  );
-  send_immediate(
-    token, left<ZswapCoinPublicKey, ContractAddress>(recipient), 100000000
+    left<ZswapCoinPublicKey, ContractAddress>(recipient)
   );
 }


### PR DESCRIPTION
1. Using mint + send_immediate was unnecessary. It should work, but mint directly works too
2. Wrong encoding was provided for coin address. This is something that needs to be kept in mind. By default ledger implementation of serialization of byte arrays adds a header indicating length and (usually) network id. But Compact does not know about these, so when handling ledger-hex-serialized data structures at the Compact <-> DApp boundary, the encode/decode functions are needed to be used. When Bech32 is supported across the board it will be easier to spot because of a format difference.